### PR TITLE
Address SonarQube code smells

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,9 @@ Naming/FileName:
 Style/Documentation:
   Enabled: false
 
+Style/ModuleFunction:
+  EnforcedStyle: extend_self
+
 Style/MutableConstant:
   Enabled: true
 

--- a/lib/name_tamer/strings/approximations.rb
+++ b/lib/name_tamer/strings/approximations.rb
@@ -4,7 +4,7 @@
 # see https://github.com/svenfuchs/i18n/blob/master/lib/i18n/backend/transliterator.rb
 module NameTamer
   module Strings
-    module_function
+    extend self
 
     # Any characters that resemble latin characters might usefully be
     # transliterated into ones that are easy to type on an anglophone

--- a/lib/name_tamer/strings/bad_encoding.rb
+++ b/lib/name_tamer/strings/bad_encoding.rb
@@ -6,7 +6,7 @@
 # Useful table here http://www.i18nqa.com/debug/utf8-debug.html
 module NameTamer
   module Strings
-    module_function
+    extend self
 
     # Strings that were wrongly encoded with single-byte encodings sometimes
     # have tell-tale substrings that we can put back into the correct UTF-8

--- a/lib/name_tamer/strings/capitalization.rb
+++ b/lib/name_tamer/strings/capitalization.rb
@@ -2,7 +2,7 @@
 
 module NameTamer
   module Strings
-    module_function
+    extend self
 
     def upcase_first_letter(string)
       string.gsub(/\b\w/, &:upcase)

--- a/lib/name_tamer/strings/compound_names.rb
+++ b/lib/name_tamer/strings/compound_names.rb
@@ -2,7 +2,7 @@
 
 module NameTamer
   module Strings
-    module_function
+    extend self
 
     # Fix known last names that have spaces (not hyphens!)
     def nbsp_in_compound_name(string)

--- a/lib/name_tamer/strings/core.rb
+++ b/lib/name_tamer/strings/core.rb
@@ -4,7 +4,7 @@ module NameTamer
   # Pure string transformations used throughout the gem. Every method
   # takes a string and returns a new string; arguments are never mutated.
   module Strings
-    module_function
+    extend self
 
     def presence(string)
       string unless string.empty?

--- a/lib/name_tamer/strings/name_modifiers.rb
+++ b/lib/name_tamer/strings/name_modifiers.rb
@@ -2,7 +2,7 @@
 
 module NameTamer
   module Strings
-    module_function
+    extend self
 
     # Fixes for name modifiers followed by space
     # Also replaces spaces with non-breaking spaces

--- a/lib/name_tamer/strings/spacing.rb
+++ b/lib/name_tamer/strings/spacing.rb
@@ -2,7 +2,7 @@
 
 module NameTamer
   module Strings
-    module_function
+    extend self
 
     # Ensure commas have exactly one space after them
     def space_around_comma(string)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-unless ENV['NO_SIMPLECOV']
-  require 'simplecov'
+require 'simplecov'
 
+unless ENV['NO_SIMPLECOV']
   SimpleCov.start do
     enable_coverage :branch
     add_filter '/spec/'


### PR DESCRIPTION
Clears the 8 open issues SonarCloud reported on main after PR #49 merged:

- **7x \`rubydre:S7918\`**: the \`NameTamer::Strings\` modules now use \`extend self\` instead of \`module_function\`. Nothing includes these modules, so \`module_function\`'s private instance-method copies were unused; \`extend self\` provides the same \`Strings.foo(...)\` call style without them. RuboCop's \`Style/ModuleFunction\` cop is set to \`extend_self\` so the two tools agree.
- **1x \`rubydre:S7816\`**: \`require 'simplecov'\` moves to the top of \`spec_helper.rb\`; only \`SimpleCov.start\` remains behind the \`NO_SIMPLECOV\` guard, preserving the opt-out.

Suite green in both coverage modes (36 examples, 100% line + branch), RuboCop clean.