### PR TITLE
Escape the replacement character in the bad-encoding table

### DIFF
--- a/lib/name_tamer/strings/bad_encoding.rb
+++ b/lib/name_tamer/strings/bad_encoding.rb
@@ -129,7 +129,7 @@ module NameTamer
       'Ã›' => 'Û',
       'Ã€' => 'À',
       'Ã™' => 'Ù',
-      'Ã�' => 'Á',
+      "Ã\uFFFD" => 'Á', # second byte of mangled Á decodes to U+FFFD REPLACEMENT CHARACTER
       'Å ' => 'Š',
       'Å¡' => 'š',
       'Å¸' => 'Ÿ',

--- a/spec/name_tamer/strings_spec.rb
+++ b/spec/name_tamer/strings_spec.rb
@@ -59,5 +59,9 @@ describe NameTamer::Strings do
     it 'repairs tell-tale double-encoded UTF-8 sequences' do
       expect(described_class.fix_encoding_errors('RenÃ© Descartes')).to eq('René Descartes')
     end
+
+    it 'repairs a mangled Á whose second byte was lost to the replacement character' do
+      expect(described_class.fix_encoding_errors("Ã\uFFFDlvarez")).to eq('Álvarez')
+    end
   end
 end


### PR DESCRIPTION
Fixes the SonarQube warning "There are problems with file encoding in the source code": the scanner flagged a literal U+FFFD REPLACEMENT CHARACTER in one `BAD_ENCODING` key (`lib/name_tamer/strings/bad_encoding.rb:132`) as suspected corruption.

The character is actually intentional there (real-world mojibake of A-acute arrives as `Ã` + U+FFFD because the second byte is undecodable), so the fix spells it with a backslash-u escape instead of the raw character. The string value, and therefore behaviour, is byte-for-byte identical; a new spec pins the mapping. A matching literal in the new spec is escaped the same way so the warning cannot reappear from `spec/`.

Suite green (37 examples, 100% line + branch), RuboCop clean.