### PR TITLE
fix: Write the replacement character in the bad-encoding table as an …

### DIFF
--- a/lib/name_tamer/strings/bad_encoding.rb
+++ b/lib/name_tamer/strings/bad_encoding.rb
@@ -129,7 +129,7 @@ module NameTamer
       'Ã›' => 'Û',
       'Ã€' => 'À',
       'Ã™' => 'Ù',
-      'Ã�' => 'Á',
+      "Ã\uFFFD" => 'Á', # second byte of mangled Á decodes to U+FFFD REPLACEMENT CHARACTER
       'Å ' => 'Š',
       'Å¡' => 'š',
       'Å¸' => 'Ÿ',

--- a/spec/name_tamer/strings_spec.rb
+++ b/spec/name_tamer/strings_spec.rb
@@ -59,5 +59,9 @@ describe NameTamer::Strings do
     it 'repairs tell-tale double-encoded UTF-8 sequences' do
       expect(described_class.fix_encoding_errors('RenÃ© Descartes')).to eq('René Descartes')
     end
+
+    it 'repairs a mangled Á whose second byte was lost to the replacement character' do
+      expect(described_class.fix_encoding_errors("Ã\uFFFDlvarez")).to eq('Álvarez')
+    end
   end
 end


### PR DESCRIPTION
…escape

One BAD_ENCODING key contained a literal U+FFFD REPLACEMENT CHARACTER (the second byte of a mangled A-acute cannot be decoded, so whatever built the table substituted U+FFFD). SonarQube flagged the raw character as suspected file corruption. The key now spells it with a backslash-u escape: the string value, and therefore the repair behaviour, is unchanged, and a new spec pins the mapping.